### PR TITLE
Update role.yaml to allow queries on ingressclasses

### DIFF
--- a/charts/jaeger-operator/templates/role.yaml
+++ b/charts/jaeger-operator/templates/role.yaml
@@ -234,6 +234,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings


### PR DESCRIPTION
The updated jaeger-operator is querying the cluster to know informations about ingressclasses. But the role created by the jaeger-operator helm chart doesn't allow get or list on ingressclasses.

This change addresses that.

#### What this PR does

#### Which issue this PR fixes

- fixes #549
